### PR TITLE
May as well give them something that compiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-cmake-build-debug
+*build*
 .DS_Store
 .idea
 *.aux
 *.log
+.vscode
+
+src/flex
+src/bison

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,41 @@
-cmake_minimum_required(VERSION 3.8)
+#Minimum allowed version of cmake for this configuration.
+cmake_minimum_required(VERSION 3.2)
 
+#Project name is mandatory
 project(cilisp)
 
-SET(CMAKE_C_FLAGS "-m64 -g -O0 -D_DEBUG -Wall")
+#Creating an executable
+add_executable(cilisp)
 
-set(SOURCE_FILES
-        src/ciLisp.c
-        ${CMAKE_CURRENT_BINARY_DIR}/ciLispScanner.c
-        ${CMAKE_CURRENT_BINARY_DIR}/ciLispParser.c
-        )
-
-include_directories(AFTER src ${CMAKE_CURRENT_BINARY_DIR})
-
-find_package(BISON)
-find_package(FLEX)
-
-BISON_TARGET(ciLispParser src/ciLisp.y ${CMAKE_CURRENT_BINARY_DIR}/ciLispParser.c VERBOSE)
-FLEX_TARGET(ciLispScanner src/ciLisp.l ${CMAKE_CURRENT_BINARY_DIR}/ciLispScanner.c)
-
-ADD_FLEX_BISON_DEPENDENCY(ciLispScanner ciLispParser)
-
-add_executable(
-        cilisp
-        ${SOURCE_FILES}
-        ${BISON_ciLispParser_OUTPUTS}
-        ${FLEX_ciLispScanner_OUTPUTS}
-)
-
+#Forcing all compilation to be with C11 Standard
 set_property(TARGET cilisp PROPERTY C_STANDARD 11)
 set_property(TARGET cilisp PROPERTY C_STANDARD_REQUIRED ON)
 
+#Turning on MANY warnings
+target_compile_options(cilisp PRIVATE -Wall -Wextra -Wpedantic)
+
+#Allow folders/files in ./scr to be includable to all .c/.h files
+target_include_directories(cilisp PRIVATE src)
+
+#Allow build directory to be #include-able to all .c/.h files
+target_include_directories(cilisp PRIVATE src/flex)
+target_include_directories(cilisp PRIVATE src/bison)
+
+#include Flex and Bison in this project
+find_package(FLEX)
+find_package(BISON)
+
+#Create a Flex target and a Bison target that output .c and .h files
+#These targets (unlike cilisp) don't create executables nor libraries
+FLEX_TARGET(ciLispScanner src/ciLisp.l ${CMAKE_SOURCE_DIR}/src/flex/ciLispScanner.c COMPILE_FLAGS)
+BISON_TARGET(ciLispParser src/ciLisp.y ${CMAKE_SOURCE_DIR}/src/bison/ciLispParser.c VERBOSE COMPILE_FLAGS "-Wall")
+ADD_FLEX_BISON_DEPENDENCY(ciLispScanner ciLispParser)
+
+#Add all the source files to cilisp target
+target_sources(cilisp PRIVATE src/builtin.c src/builtin.h)
+target_sources(cilisp PRIVATE src/ciLisp.c src/ciLisp.h)
+target_sources(cilisp PRIVATE ${BISON_ciLispParser_OUTPUTS})
+target_sources(cilisp PRIVATE ${FLEX_ciLispScanner_OUTPUTS})
+
+#Link the math library to cilisp because math.h needs it :/
 target_link_libraries(cilisp m)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set_property(TARGET cilisp PROPERTY C_STANDARD 11)
 set_property(TARGET cilisp PROPERTY C_STANDARD_REQUIRED ON)
 
 #Turning on MANY warnings
-target_compile_options(cilisp PRIVATE -Wall -Wextra -Wpedantic)
+target_compile_options(cilisp PRIVATE -Wall)
 
 #Allow folders/files in ./scr to be includable to all .c/.h files
 target_include_directories(cilisp PRIVATE src)
@@ -25,14 +25,14 @@ target_include_directories(cilisp PRIVATE src/bison)
 find_package(FLEX)
 find_package(BISON)
 
-#Create a Flex target and a Bison target that output .c and .h files
+#Create a Flex target and a Bison target that output .c files
 #These targets (unlike cilisp) don't create executables nor libraries
 FLEX_TARGET(ciLispScanner src/ciLisp.l ${CMAKE_SOURCE_DIR}/src/flex/ciLispScanner.c COMPILE_FLAGS)
 BISON_TARGET(ciLispParser src/ciLisp.y ${CMAKE_SOURCE_DIR}/src/bison/ciLispParser.c VERBOSE COMPILE_FLAGS "-Wall")
+#Make the bison target also generate a .h file
 ADD_FLEX_BISON_DEPENDENCY(ciLispScanner ciLispParser)
 
 #Add all the source files to cilisp target
-target_sources(cilisp PRIVATE src/builtin.c src/builtin.h)
 target_sources(cilisp PRIVATE src/ciLisp.c src/ciLisp.h)
 target_sources(cilisp PRIVATE ${BISON_ciLispParser_OUTPUTS})
 target_sources(cilisp PRIVATE ${FLEX_ciLispScanner_OUTPUTS})

--- a/src/ciLisp.c
+++ b/src/ciLisp.c
@@ -87,7 +87,7 @@ AST_NODE *createFunctionNode(char *funcName, AST_NODE *opList)
     // For CUSTOM_OPER functions, you should simply assign the "ident" pointer to the passed in funcName.
     // For functions other than CUSTOM_OPER, you should free the funcName after you've assigned the OPER_TYPE.
 
-    return node;
+    return NULL;
 }
 
 
@@ -98,6 +98,7 @@ AST_NODE *createFunctionNode(char *funcName, AST_NODE *opList)
 AST_NODE *addOperandToList(AST_NODE *newHead, AST_NODE *list)
 {
     // TODO
+    return NULL;
 }
 
 
@@ -114,8 +115,6 @@ RET_VAL evalNumNode(AST_NODE *node)
 
     // TODO populate result with the values stored in the node.
     // SEE: AST_NODE, AST_NODE_TYPE, NUM_AST_NODE
-
-
     return result;
 }
 

--- a/src/ciLisp.y
+++ b/src/ciLisp.y
@@ -12,7 +12,7 @@
 %token <dval> INT DOUBLE
 %token LPAREN RPAREN EOL QUIT
 
-%type <astNode> s_expr f_expr number
+%type <astNode> s_expr f_expr number s_expr_list
 
 %%
 


### PR DESCRIPTION
I can see an argument for pulling out 's_expr_list' from the list of tokens, but then you may as well delete all that other code in the .y except the bare basics.