### PR TITLE
Was able to find a way to remove the getline reimplementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-cmake-build-debug
+*build*
 .DS_Store
 .idea
 *.aux
 *.log
+.vscode
+
+src/flex
+src/bison

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,41 @@
-cmake_minimum_required(VERSION 3.8)
+#Minimum allowed version of cmake for this configuration.
+cmake_minimum_required(VERSION 3.2)
 
+#Project name is mandatory
 project(cilisp)
 
-SET(CMAKE_C_FLAGS "-m64 -g -O0 -D_DEBUG -Wall")
+#Creating an executable
+add_executable(cilisp)
 
-set(SOURCE_FILES
-        src/ciLisp.c
-        ${CMAKE_CURRENT_BINARY_DIR}/ciLispScanner.c
-        ${CMAKE_CURRENT_BINARY_DIR}/ciLispParser.c
-        )
-
-include_directories(AFTER src ${CMAKE_CURRENT_BINARY_DIR})
-
-find_package(BISON)
-find_package(FLEX)
-
-BISON_TARGET(ciLispParser src/ciLisp.y ${CMAKE_CURRENT_BINARY_DIR}/ciLispParser.c VERBOSE)
-FLEX_TARGET(ciLispScanner src/ciLisp.l ${CMAKE_CURRENT_BINARY_DIR}/ciLispScanner.c)
-
-ADD_FLEX_BISON_DEPENDENCY(ciLispScanner ciLispParser)
-
-add_executable(
-        cilisp
-        ${SOURCE_FILES}
-        ${BISON_ciLispParser_OUTPUTS}
-        ${FLEX_ciLispScanner_OUTPUTS}
-)
-
+#Forcing all compilation to be with C11 Standard
 set_property(TARGET cilisp PROPERTY C_STANDARD 11)
 set_property(TARGET cilisp PROPERTY C_STANDARD_REQUIRED ON)
 
+#Turning on MANY warnings
+target_compile_options(cilisp PRIVATE -Wall -Wextra -Wpedantic)
+
+#Allow folders/files in ./scr to be includable to all .c/.h files
+target_include_directories(cilisp PRIVATE src)
+
+#Allow build directory to be #include-able to all .c/.h files
+target_include_directories(cilisp PRIVATE src/flex)
+target_include_directories(cilisp PRIVATE src/bison)
+
+#include Flex and Bison in this project
+find_package(FLEX)
+find_package(BISON)
+
+#Create a Flex target and a Bison target that output .c and .h files
+#These targets (unlike cilisp) don't create executables nor libraries
+FLEX_TARGET(ciLispScanner src/ciLisp.l ${CMAKE_SOURCE_DIR}/src/flex/ciLispScanner.c COMPILE_FLAGS)
+BISON_TARGET(ciLispParser src/ciLisp.y ${CMAKE_SOURCE_DIR}/src/bison/ciLispParser.c VERBOSE COMPILE_FLAGS "-Wall")
+ADD_FLEX_BISON_DEPENDENCY(ciLispScanner ciLispParser)
+
+#Add all the source files to cilisp target
+target_sources(cilisp PRIVATE src/builtin.c src/builtin.h)
+target_sources(cilisp PRIVATE src/ciLisp.c src/ciLisp.h)
+target_sources(cilisp PRIVATE ${BISON_ciLispParser_OUTPUTS})
+target_sources(cilisp PRIVATE ${FLEX_ciLispScanner_OUTPUTS})
+
+#Link the math library to cilisp because math.h needs it :/
 target_link_libraries(cilisp m)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set_property(TARGET cilisp PROPERTY C_STANDARD 11)
 set_property(TARGET cilisp PROPERTY C_STANDARD_REQUIRED ON)
 
 #Turning on MANY warnings
-target_compile_options(cilisp PRIVATE -Wall -Wextra -Wpedantic)
+target_compile_options(cilisp PRIVATE -Wall)
 
 #Allow folders/files in ./scr to be includable to all .c/.h files
 target_include_directories(cilisp PRIVATE src)
@@ -25,14 +25,14 @@ target_include_directories(cilisp PRIVATE src/bison)
 find_package(FLEX)
 find_package(BISON)
 
-#Create a Flex target and a Bison target that output .c and .h files
+#Create a Flex target and a Bison target that output .c files
 #These targets (unlike cilisp) don't create executables nor libraries
 FLEX_TARGET(ciLispScanner src/ciLisp.l ${CMAKE_SOURCE_DIR}/src/flex/ciLispScanner.c COMPILE_FLAGS)
 BISON_TARGET(ciLispParser src/ciLisp.y ${CMAKE_SOURCE_DIR}/src/bison/ciLispParser.c VERBOSE COMPILE_FLAGS "-Wall")
+#Make the bison target also generate a .h file
 ADD_FLEX_BISON_DEPENDENCY(ciLispScanner ciLispParser)
 
 #Add all the source files to cilisp target
-target_sources(cilisp PRIVATE src/builtin.c src/builtin.h)
 target_sources(cilisp PRIVATE src/ciLisp.c src/ciLisp.h)
 target_sources(cilisp PRIVATE ${BISON_ciLispParser_OUTPUTS})
 target_sources(cilisp PRIVATE ${FLEX_ciLispScanner_OUTPUTS})

--- a/src/ciLisp.c
+++ b/src/ciLisp.c
@@ -87,7 +87,7 @@ AST_NODE *createFunctionNode(char *funcName, AST_NODE *opList)
     // For CUSTOM_OPER functions, you should simply assign the "ident" pointer to the passed in funcName.
     // For functions other than CUSTOM_OPER, you should free the funcName after you've assigned the OPER_TYPE.
 
-    return node;
+    return NULL;
 }
 
 
@@ -98,6 +98,7 @@ AST_NODE *createFunctionNode(char *funcName, AST_NODE *opList)
 AST_NODE *addOperandToList(AST_NODE *newHead, AST_NODE *list)
 {
     // TODO
+    return NULL;
 }
 
 
@@ -114,8 +115,6 @@ RET_VAL evalNumNode(AST_NODE *node)
 
     // TODO populate result with the values stored in the node.
     // SEE: AST_NODE, AST_NODE_TYPE, NUM_AST_NODE
-
-
     return result;
 }
 

--- a/src/ciLisp.l
+++ b/src/ciLisp.l
@@ -12,15 +12,16 @@ func "neg"|"abs"|"add"|"sub"|"mult"|"div"
 
 %%
 
+"quit" {
+    return QUIT;
+    }
+
 {int} {
     yylval.dval = strtod(yytext, NULL);
     fprintf(stderr, "lex: INT dval = %lf\n", yylval.dval);
     return INT;
-}
-
-"quit" {
-    return QUIT;
     }
+
 
 {func} {
     yylval.sval = (char *) malloc(strlen(yytext)*sizeof(char)+1);
@@ -34,8 +35,14 @@ func "neg"|"abs"|"add"|"sub"|"mult"|"div"
     YY_FLUSH_BUFFER;
     return EOL;
     }
+    
+<<EOF>>  {
+    fprintf(stderr, "lex: EOF\n");
+    return EOFT;
+    }
 
 [ \t] ; /* skip whitespace */
+
 
 . { // anything else
     printf("ERROR: invalid character: >>%s<<\n", yytext);
@@ -51,86 +58,16 @@ func "neg"|"abs"|"add"|"sub"|"mult"|"div"
  */
 
 #include <stdio.h>
-#include <stdlib.h>
 
-size_t readline(char **lineptr, size_t *n, FILE *stream, size_t n_terminate) {
-    char *bufptr = NULL;
-    char *p = bufptr;
-    size_t size;
-    int c;
-
-    if (lineptr == NULL) {
-        return -1;
-    }
-    if (stream == NULL) {
-        return -1;
-    }
-    if (n == NULL) {
-        return -1;
-    }
-    bufptr = *lineptr;
-    size = *n;
-
-    c = fgetc(stream);
-    if (c == EOF) {
-        return -1;
-    }
-    if (bufptr == NULL) {
-        bufptr = malloc(128);
-        if (bufptr == NULL) {
-            return -1;
-        }
-        size = 128;
-    }
-    p = bufptr;
-    while(c != EOF) {
-        if ((p - bufptr + 1 + n_terminate) > (size)) {
-            int offset = p - bufptr;
-            size = size + 128;
-            bufptr = realloc(bufptr, size);
-            if (bufptr == NULL) {
-                return -1;
-            }
-            p = bufptr + offset;
-        }
-        *p++ = c;
-        if (c == '\n') {
-            break;
-        }
-        c = fgetc(stream);
-    }
-
-    while( n_terminate > 0)
-    {
-        *p++ = '\0';
-        n_terminate--;
-    }
-
-    *n = p - bufptr;
-    bufptr = realloc(bufptr, *n);
-    *lineptr = bufptr;
-
-    return p - bufptr;
-}
-
-
-int main(void) {
-
+int main(void) 
+{
+    //Uncomment to remove logging.
     freopen("/dev/null", "w", stderr);
 
-    char *s_expr_str;
-    size_t s_expr_str_len;
-    size_t s_expr_postfix_padding = 2;
-    YY_BUFFER_STATE buffer;
-    while (true) {
-        printf("\n> ");
-        s_expr_str = NULL;
-        s_expr_str_len = 0;
-        readline(&s_expr_str, &s_expr_str_len, stdin, s_expr_postfix_padding);
-        buffer = yy_scan_buffer(s_expr_str, s_expr_str_len);
-        yyparse();
-        yy_delete_buffer(buffer);
+    while(1) {
+        printf(">: ");
+        if (yyparse()) {
+            YY_FLUSH_BUFFER;
+        }
     }
-
-    free(s_expr_str);
 }

--- a/src/ciLisp.y
+++ b/src/ciLisp.y
@@ -10,7 +10,7 @@
 
 %token <sval> FUNC
 %token <dval> INT DOUBLE
-%token LPAREN RPAREN EOL QUIT
+%token LPAREN RPAREN EOL QUIT EOFT
 
 %type <astNode> s_expr f_expr number s_expr_list
 
@@ -21,8 +21,18 @@ program:
         fprintf(stderr, "yacc: program ::= s_expr EOL\n");
         if ($1) {
             printRetVal(eval($1));
-            freeNode($1);
+            YYACCEPT;
         }
+    }
+    | s_expr EOFT {
+        fprintf(stderr, "yacc: program ::= s_expr EOFT\n");
+        if ($1) {
+            printRetVal(eval($1));
+        }
+        exit(EXIT_SUCCESS);
+    }
+    | EOFT {
+        exit(EXIT_SUCCESS);
     };
 
 s_expr:

--- a/src/ciLisp.y
+++ b/src/ciLisp.y
@@ -12,7 +12,7 @@
 %token <dval> INT DOUBLE
 %token LPAREN RPAREN EOL QUIT
 
-%type <astNode> s_expr f_expr number
+%type <astNode> s_expr f_expr number s_expr_list
 
 %%
 


### PR DESCRIPTION
`yyparse()` is what was able to make it happen.

[yyparse documentation](https://www.gnu.org/software/bison/manual/html_node/Parser-Function.html)